### PR TITLE
Update claymores.py

### DIFF
--- a/miners/claymores.py
+++ b/miners/claymores.py
@@ -77,7 +77,7 @@ class Claymores(object):
 	    while i < len(temp) - 1:
                 data.temps.append(temp[i])
                 data.fan_speeds.append(temp[i + 1])
-		i += 1
+		i += 2
 
             data.online = self.connected
         except Exception, e:


### PR DESCRIPTION
getting double gpus in site ethmonitoring because of this
            # Temps and fan speeds
            temp = summary_response[6].split(';')
	    i = 0
	    while i < len(temp) - 1:
                data.temps.append(temp[i])
                data.fan_speeds.append(temp[i + 1])
		i += 1
however it must be i +=2